### PR TITLE
Change behavior for GigaChatConfig::default()

### DIFF
--- a/examples/chat_completions.rs
+++ b/examples/chat_completions.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let config = GigaChatConfig::default();
+    let config = GigaChatConfig::new();
 
     let client: Client = Client::with_config(config);
 

--- a/examples/cli_chat.rs
+++ b/examples/cli_chat.rs
@@ -13,7 +13,8 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let config = GigaChatConfig::default();
+    let config = GigaChatConfig::new();
+    println!("{:?}", &config);
 
     let client: Client = Client::with_config(config);
 

--- a/examples/cli_chat_stream.rs
+++ b/examples/cli_chat_stream.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let config = GigaChatConfig::default();
+    let config = GigaChatConfig::new();
 
     let client: Client = Client::with_config(config);
 

--- a/examples/models.rs
+++ b/examples/models.rs
@@ -6,7 +6,7 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let config = GigaChatConfig::default();
+    let config = GigaChatConfig::new();
 
     let client = Client::with_config(config);
 

--- a/examples/tokens.rs
+++ b/examples/tokens.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<()> {
 
     tracing_subscriber::fmt::init();
 
-    let config = GigaChatConfig::default();
+    let config = GigaChatConfig::new();
 
     let client = Client::with_config(config);
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -73,7 +73,7 @@ impl Client {
                 reqwest::header::CONTENT_TYPE,
                 "application/x-www-form-urlencoded",
             )
-            .bearer_auth(self.config.auth_token.clone())
+            .bearer_auth(self.config.auth_token.clone().unwrap())
             .body(format!("scope={}", self.config.scope))
             .send()
             .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
 use crate::api::{API_BASE_URL, AUTH_URL, SCOPE_CORPORATE, SCOPE_PERSONAL};
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct GigaChatConfig {
-    pub auth_token: String,
+    pub auth_token: Option<String>,
     pub scope: String,
     pub auth_url: String,
     pub api_base_url: String,
@@ -10,7 +10,13 @@ pub struct GigaChatConfig {
 
 impl GigaChatConfig {
     pub fn new() -> Self {
-        GigaChatConfig::default()
+        Self {
+            auth_token: Some(
+                std::env::var("GIGACHAT_AUTH_TOKEN")
+                    .expect("The environment variable GIGACHAT_AUTH_TOKEN is not set"),
+            ),
+            ..GigaChatConfig::default()
+        }
     }
 
     pub fn builder() -> GigaChatConfigBuilder {
@@ -21,8 +27,7 @@ impl GigaChatConfig {
 impl Default for GigaChatConfig {
     fn default() -> Self {
         Self {
-            auth_token: std::env::var("GIGACHAT_AUTH_TOKEN")
-                .expect("The environment variable GIGACHAT_AUTH_TOKEN is not set"),
+            auth_token: None,
             scope: std::env::var("GIGACHAT_API_SCOPE").unwrap_or(SCOPE_PERSONAL.into()),
             auth_url: AUTH_URL.to_owned(),
             api_base_url: API_BASE_URL.to_owned(),
@@ -92,7 +97,10 @@ impl GigaChatConfigBuilder {
         let config = GigaChatConfig::default();
 
         GigaChatConfig {
-            auth_token: self.auth_token.unwrap_or(config.auth_token),
+            auth_token: match self.auth_token {
+                Some(token) => Some(token),
+                None => config.auth_token,
+            },
             scope: self.scope.unwrap_or(config.scope),
             auth_url: self.auth_url.unwrap_or(AUTH_URL.to_owned()),
             api_base_url: self.api_base_url.unwrap_or(API_BASE_URL.to_owned()),


### PR DESCRIPTION
  Before this changes any application which will use this library, must
  asking user to provide env variable before to use the app. Now it's
  possible to be friendly for users and ask them to provide auth_token
  later.  

  Also, initialization for new Config was ::default method in examples, but I
  suppose default method must do creation only default values and don't try to setup
  a full object if some params are necessary for manual setup, in our case
  it's auth_token. And ::new method is for creation a full object based on defaults and user's data.

  This PR fixes #2 